### PR TITLE
fix: convert KSH input to HBAR for tipping

### DIFF
--- a/frontend/src/components/tokenomics/TipButton.jsx
+++ b/frontend/src/components/tokenomics/TipButton.jsx
@@ -15,9 +15,11 @@ export default function TipButton({ postId, recipientId, recipientName, onTipSen
 
     setIsLoading(true);
     try {
+      // Convert KSH to HBAR (1 HBAR = 50 KSH)
+      const hbarAmount = parseFloat(amount) / 50;
       const transaction = await tokenomics.sendTip(
         recipientId,
-        parseFloat(amount),
+        hbarAmount,
         message
       );
       


### PR DESCRIPTION
- Fix TipButton to convert user KSH input to HBAR before sending
- User inputs KSH amount (e.g., 100 KSH)
- System converts to HBAR (100 ÷ 50 = 2.0 HBAR)
- Proper HBAR amount sent to backend and Hedera network
- Maintains user-friendly KSH interface with accurate blockchain transfers